### PR TITLE
Fix: Sitemap generation with custom 404 permalink

### DIFF
--- a/listeners/GenerateSitemap.php
+++ b/listeners/GenerateSitemap.php
@@ -10,7 +10,8 @@ class GenerateSitemap
     protected $exclude = [
         '/assets/*',
         '*/favicon.ico',
-        '*/404'
+        '*/404',
+        '404*'
     ];
 
     public function handle(Jigsaw $jigsaw)


### PR DESCRIPTION
**Problem:**
- You need a custom 404 permalink for Netlify: `/404.html`
- The solution described in [Jigsaw's docs](https://jigsaw.tighten.co/docs/custom-404-page/) – YAML frontmatter: `permalink: 404.html` creates a build error

```bash
In Sitemap.php line 243:

  The location must be a valid URL. You have specified: http://localhost:3000
  404.html.
```

**Solution:**
- Just add `404*` to excluded paths in the `GenerateSitemap.php` listener