### PR TITLE
Allow customizing of excerpt per post

### DIFF
--- a/config.php
+++ b/config.php
@@ -29,8 +29,9 @@ return [
         return Datetime::createFromFormat('U', $page->date);
     },
     'getExcerpt' => function ($page, $length = 255) {
+        $content = $page->excerpt ?? $page->getContent();
         $cleaned = strip_tags(
-            preg_replace(['/<pre>[\w\W]*?<\/pre>/', '/<h\d>[\w\W]*?<\/h\d>/'], '', $page->getContent()),
+            preg_replace(['/<pre>[\w\W]*?<\/pre>/', '/<h\d>[\w\W]*?<\/h\d>/'], '', $content),
             '<code>'
         );
 

--- a/config.php
+++ b/config.php
@@ -28,7 +28,7 @@ return [
     'getDate' => function ($page) {
         return Datetime::createFromFormat('U', $page->date);
     },
-    'excerpt' => function ($page, $length = 255) {
+    'getExcerpt' => function ($page, $length = 255) {
         $cleaned = strip_tags(
             preg_replace(['/<pre>[\w\W]*?<\/pre>/', '/<h\d>[\w\W]*?<\/h\d>/'], '', $page->getContent()),
             '<code>'

--- a/listeners/GenerateIndex.php
+++ b/listeners/GenerateIndex.php
@@ -13,7 +13,7 @@ class GenerateIndex
                 'title' => $page->title,
                 'categories' => $page->categories,
                 'link' => rightTrimPath($jigsaw->getConfig('baseUrl')) . $page->getPath(),
-                'snippet' => $page->excerpt(),
+                'snippet' => $page->getExcerpt(),
             ];
         })->values());
 

--- a/source/_components/post-as-rss-item.blade.php
+++ b/source/_components/post-as-rss-item.blade.php
@@ -7,7 +7,7 @@
     <author>
         <name>{{ $entry->author }}</name>
     </author>
-    <summary type="html">{{ $entry->excerpt() }}...</summary>
+    <summary type="html">{{ $entry->getExcerpt() }}...</summary>
     <content type="html"><![CDATA[
         @include('_posts.' . $entry->getFilename())
     ]]></content>

--- a/source/_components/post-preview-inline.blade.php
+++ b/source/_components/post-preview-inline.blade.php
@@ -11,7 +11,7 @@
         >{{ $post->title }}</a>
     </h2>
 
-    <p class="mb-4 mt-0">{!! $post->excerpt(200) !!}</p>
+    <p class="mb-4 mt-0">{!! $post->getExcerpt(200) !!}</p>
 
     <a
         href="{{ $post->getUrl() }}"

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -24,7 +24,7 @@
                 </a>
             </h2>
 
-            <p class="mt-0 mb-4">{!! $featuredPost->excerpt() !!}</p>
+            <p class="mt-0 mb-4">{!! $featuredPost->getExcerpt() !!}</p>
 
             <a href="{{ $featuredPost->getUrl() }}" title="Read - {{ $featuredPost->title }}"class="uppercase tracking-wide mb-4">
                 Read


### PR DESCRIPTION
I ran into an issue where I wanted to customize the excerpt for some of my posts.

In order to do so I renamed the `excerpt` function to `getExcerpt` so I could set a new excerpt like this:

```
---
extends: _layouts.post
section: content
title: Automating Laravel Homestead On Windows
date: 2017-01-06
description: Make your computer setup a new site in homestead for you
categories: [laravel, homestead, bash]
cover_image: /assets/img/featured/automating-homestead.jpg
excerpt: "I recently switched back to running Windows from Ubuntu on my work computer. When I was running Ubuntu I used a fork of Laravel Valet which worked great. Now that I’m back on Windows I knew I wanted to setup Homestead again since I had issues running the Windows fork of Valet due to DNS configuration at my office."
---
```