### PR TITLE
Update index to use site description variable

### DIFF
--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -4,7 +4,7 @@
     <meta property="og:title" content="{{ $page->siteName }}" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="{{ $page->getUrl() }}"/>
-    <meta property="og:description" content="{{ $page->blogDescription }}" />
+    <meta property="og:description" content="{{ $page->siteDescription }}" />
 @endpush
 
 @section('body')


### PR DESCRIPTION
There is no blog description variable used within the preset as far as I can see. Either the index blade needs to be updated or the configuration. I believe the index blade is the correct place to update this.