### PR TITLE
Fix missing space in template and sitemap exclude rules

### DIFF
--- a/listeners/GenerateSitemap.php
+++ b/listeners/GenerateSitemap.php
@@ -10,7 +10,7 @@ class GenerateSitemap
     protected $exclude = [
         '/assets/*',
         '*/favicon.ico',
-        '*/404'
+        '*/404*'
     ];
 
     public function handle(Jigsaw $jigsaw)

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -19,7 +19,7 @@
 
             <p class="mt-0 mb-4">{!! $featuredPost->getExcerpt() !!}</p>
 
-            <a href="{{ $featuredPost->getUrl() }}" title="Read - {{ $featuredPost->title }}"class="uppercase tracking-wide mb-4">
+            <a href="{{ $featuredPost->getUrl() }}" title="Read - {{ $featuredPost->title }}" class="uppercase tracking-wide mb-4">
                 Read
             </a>
         </div>


### PR DESCRIPTION
- Adds a missing space before "class" in `index.blade.php` (addresses #36)
- Updates the `exclude` array in `GenerateSitemap.php` to catch 404 pages with different extensions (addresses #29) 
