### PR TITLE
Add support for flexible, "DRYer" excerpts using `<!-- more -->` marker

### DIFF
--- a/config.php
+++ b/config.php
@@ -29,7 +29,7 @@ return [
         return Datetime::createFromFormat('U', $page->date);
     },
     'getExcerpt' => function ($page, $length = 255) {
-        $content = $page->excerpt ?? $page->getContent();
+        $content = $page->excerpt ?? rtrim(preg_split('/^<!-- more -->$/m', $page->getContent(), 2)[0]);
         $cleaned = strip_tags(
             preg_replace(['/<pre>[\w\W]*?<\/pre>/', '/<h\d>[\w\W]*?<\/h\d>/'], '', $content),
             '<code>'


### PR DESCRIPTION
The "out of the box" options for post excerpts are currently either:

* Grab up to `$length` characters of the "cleaned up" post contents
* Use what's provided in the `excerpt` Front Matter.

This PR adds the possibility of a third option:

* Use everything up to the `<!-- more -->` (i.e. "read more after this!") marker as the excerpt.

I'm not entirely sure what the best way to introduce this functionality would be. I don't want to break BC, so the default `getExcerpt(...)` function behavior doesn't change for anyone who _doesn't_ have a `<!-- more -->` marker in their post contents, nor will the excerpt exceed `$length` even if someone _does_ have a `<!-- more -->`marker present.

I can think of a few possibilities, all of which are not ideal:

1. Allow the presence of `<!-- more -->` to override the `$length` parameter.
    * Not ideal because the explicit `excerpt:` Front Matter doesn't behave in that way.
2. Instruct users to pass a large number to `getExcerpt(...)` in their Blade templates in order to accommodate `excerpt:` / `<!-- more -->` excerpts with higher character counts.
    * Also not ideal because it'll lengthen excerpts from posts that _don't_ explicitly provide one as well.
3. Add an optional parameter to `getExcerpt(...)` like `$explicitExcerptsOverrideLength = false`.
    * _Also_ not ideal because (a) extra optional parameters are yucky and (b) it'd change the current behavior of `excerpt:` too (though at least the user would be making the conscious decision to do so).
4. Add an optional `max_excerpt_length` variable to the Front Matter which, if present, will override the existing `$length` value in `getExcerpt(...)` for the current post only. User can then either plan on always having an explicit excerpt and make exceptions when necessary vs. defaulting to automatic excerpts and making exceptions when they want to be explicit.
    * Eh... extra parameters are yucky.
5. Change the `$length` parameter to something like `$lengthWhenGenerated`. If `excerpt:` or `<!-- more -->` are present, excerpt length is unlimited. Otherwise, all works as it currently does.
    * Changes existing behavior for `excerpt:`, but at least things are consistent.
6. Get rid of the `$length` parameter altogether and make everyone specify an `excerpt:` or provide a `<!-- more -->` marker.
    * Not ideal because it's a BC break in terms of behavior and you're already on `v1.x`, but I figured I'd mention it because that's what I'm doing on my blog.
7. say "no thanks" and close my PR 😳 j/k plz don't.

Thoughts?