### PR TITLE
css cleanup, list-reset removed from Tailwind 1.x

### DIFF
--- a/source/_layouts/master.blade.php
+++ b/source/_layouts/master.blade.php
@@ -55,7 +55,7 @@
         </main>
 
         <footer class="bg-white text-center text-sm mt-12 py-4" role="contentinfo">
-            <ul class="flex flex-col md:flex-row justify-center list-reset">
+            <ul class="flex flex-col md:flex-row justify-center">
                 <li class="md:mr-2">
                     &copy; <a href="https://tighten.co" title="Tighten website">Tighten</a> {{ date('Y') }}.
                 </li>

--- a/source/_nav/menu-responsive.blade.php
+++ b/source/_nav/menu-responsive.blade.php
@@ -1,5 +1,5 @@
 <nav id="js-nav-menu" class="nav-menu hidden lg:hidden">
-    <ul class="list-reset my-0">
+    <ul class="my-0">
         <li class="pl-4">
             <a
                 title="{{ $page->siteName }} Blog"


### PR DESCRIPTION
This is super duper minor PR, but will clean up a little cruft from the code anyway.
Tailwind 1.x removed list-reset from it's definitions, so specifying this class was a NOP.