### PR TITLE
fix: make titles consistent

### DIFF
--- a/source/_layouts/master.blade.php
+++ b/source/_layouts/master.blade.php
@@ -11,7 +11,7 @@
         <meta property="og:url" content="{{ $page->getUrl() }}"/>
         <meta property="og:description" content="{{ $page->siteDescription }}" />
 
-        <title>{{ $page->siteName }}{{ $page->title ? ' | ' . $page->title : '' }}</title>
+        <title>{{ $page->title ?  $page->title . ' | ' : '' }}{{ $page->siteName }}</title>
 
         <link rel="home" href="{{ $page->baseUrl }}">
         <link rel="icon" href="/favicon.ico">


### PR DESCRIPTION
Currently, the title tags in the master template are in opposite orders. 

The main `<title>` tag is: `sitename | page title`
The `og:title` is `page title | sitename`

IMO the sitename should be after the page title, so this PR corrects them to make them consistent.