### PR TITLE
Add support for flexible, "DRYer" excerpts using `<!-- more -->` marker

### DIFF
--- a/config.php
+++ b/config.php
@@ -29,11 +29,21 @@ return [
         return Datetime::createFromFormat('U', $page->date);
     },
     'getExcerpt' => function ($page, $length = 255) {
-        $content = $page->excerpt ?? $page->getContent();
-        $cleaned = strip_tags(
-            preg_replace(['/<pre>[\w\W]*?<\/pre>/', '/<h\d>[\w\W]*?<\/h\d>/'], '', $content),
-            '<code>'
+        if ($page->excerpt) {
+            return $page->excerpt;
+        }
+
+        $content = preg_split('/<!-- more -->/m', $page->getContent(), 2);
+        $cleaned = trim(
+            strip_tags(
+                preg_replace(['/<pre>[\w\W]*?<\/pre>/', '/<h\d>[\w\W]*?<\/h\d>/'], '', $content[0]),
+                '<code>'
+            )
         );
+
+        if (count($content) > 1) {
+            return $content[0];
+        }
 
         $truncated = substr($cleaned, 0, $length);
 

--- a/source/_posts/customizing-your-site.md
+++ b/source/_posts/customizing-your-site.md
@@ -6,6 +6,7 @@ date: 2018-12-24
 description: Customize your site with CSS and JS
 categories: [configuration]
 featured: true
+excerpt: This starter template comes pre-loaded with Tailwind CSS, a utility CSS framework that allows you to customize and build complex designs without touching a line of CSS.
 ---
 
 This starter template comes pre-loaded with [Tailwind CSS](https://tailwindcss.com), a utility CSS framework that allows you to customize and build complex designs without touching a line of CSS. There are also a few base Sass files in the `/source/_assets/sass` folder, set up with the expectation that you can add any custom CSS into `_blog.scss`.

--- a/source/_posts/getting-started.md
+++ b/source/_posts/getting-started.md
@@ -9,7 +9,7 @@ featured: true
 categories: [configuration]
 ---
 
-This is a starter template for creating a beautiful, customizable blog with minimal effort. You’ll only have to change a few settings and you’re ready to go.
+This is a starter template for creating a beautiful, customizable blog with minimal effort. You’ll only have to change a few settings and you’re ready to go.<!-- more -->
 
 ## Configuration
 


### PR DESCRIPTION
(Builds on https://github.com/tightenco/jigsaw-blog-template/pull/42)

Based on an idea from @michaelmoussa, this PR updates the `getExcerpt()` function in `config.php`, adding the ability to specify the excerpt for a post by using the `<!-- more -->` comment inline, to indicate where the content should be truncated.

This retains the ability to specify an excerpt with an `excerpt` key in the YAML front matter (which will take precedence), as well as to automatically truncate the content by passing a character length value to the `getExcerpt()` helper command (defaults to 255 characters). 

In this updated version the `$length` parameter will not apply to an explicitly-set excerpt, whether using the `expert` key or the `<!-- more -->` syntax. `$length` will only truncate automatically-generated excerpts.