### PR TITLE
Update a reference to `str_is()` to use the updated `Illuminate\Support\Str::is()` method

### DIFF
--- a/listeners/GenerateSitemap.php
+++ b/listeners/GenerateSitemap.php
@@ -4,6 +4,7 @@ namespace App\Listeners;
 
 use samdark\sitemap\Sitemap;
 use TightenCo\Jigsaw\Jigsaw;
+use Illuminate\Support\Str;
 
 class GenerateSitemap
 {
@@ -37,6 +38,6 @@ class GenerateSitemap
 
     public function isExcluded($path)
     {
-        return str_is($this->exclude, $path);
+        return Str::is($this->exclude, $path);
     }
 }


### PR DESCRIPTION
This is an update to the `GenerateSitemap` class to remove a reference to a function that was removed in the Laravel 5.7 update. 