### PR TITLE
Potential dark theme implementation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ This starter template includes samples of common page types, and comes pre-confi
 
 ---
 
-![Blog starter template screenshot](https://user-images.githubusercontent.com/357312/50345466-355c7700-04fd-11e9-83dd-f4e13ecdc97c.png)
+![Blog dark starter template screenshot](https://user-images.githubusercontent.com/20649108/74672987-460e8880-51a6-11ea-96c4-43a395d8be26.png)
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Jigsaw Blog Starter Template
+# Jigsaw Blog Dark Starter Template
 
 This is a starter template for creating a beautiful, customizable blog in Jigsaw with minimal effort. You’ll only have to change a few settings and you’re ready to go.
 

--- a/source/404.blade.php
+++ b/source/404.blade.php
@@ -1,7 +1,7 @@
 @extends('_layouts.master')
 
 @section('body')
-    <div class="flex flex-col items-center text-gray-700 mt-32">
+    <div class="flex flex-col items-center text-gray-300 mt-32">
         <h1 class="text-6xl font-light leading-none mb-2">404</h1>
 
         <h2 class="text-3xl">Page not found.</h2>

--- a/source/_assets/js/components/Search.vue
+++ b/source/_assets/js/components/Search.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="flex flex-1 justify-end items-center text-right px-4">
         <div
-            class="absolute md:relative w-full justify-end bg-white left-0 top-0 z-10 mt-7 md:mt-0 px-4 md:px-0"
+            class="absolute md:relative w-full justify-end bg-gray-900 left-0 top-0 z-10 mt-7 md:mt-0 px-4 md:px-0"
             :class="{'hidden md:flex': ! searching}"
         >
             <label for="search" class="hidden">Search</label>

--- a/source/_assets/sass/_base.scss
+++ b/source/_assets/sass/_base.scss
@@ -8,7 +8,7 @@ a {
     @apply .text-blue-600;
 
     &:hover {
-        @apply .text-blue-800;
+        @apply .text-blue-500;
     }
 }
 
@@ -19,12 +19,12 @@ blockquote {
     @apply .italic;
     @apply .my-8;
     @apply .pl-6;
-    @apply .text-gray-800;
+    @apply .text-gray-300;
     @apply .text-lg;
 }
 
 code {
-    @apply .bg-gray-300;
+    @apply .bg-gray-600;
     @apply .px-2;
     @apply .py-px;
     @apply .rounded;
@@ -52,7 +52,7 @@ h6 {
     @apply .leading-tight;
     @apply .mb-4;
     @apply .mt-8;
-    @apply .text-gray-900;
+    @apply .text-white;
 
     &:first-child {
         @apply .mt-0;

--- a/source/_assets/sass/_mailchimp.scss
+++ b/source/_assets/sass/_mailchimp.scss
@@ -30,7 +30,7 @@
         @apply .mb-6;
         @apply .text-2xl;
         @apply .text-center;
-        @apply .text-gray-900;
+        @apply .text-gray-300;
     }
 }
 

--- a/source/_assets/sass/_navigation.scss
+++ b/source/_assets/sass/_navigation.scss
@@ -1,5 +1,5 @@
 .nav-menu {
-    @apply .bg-gray-200;
+    @apply .bg-gray-700;
     @apply .pb-2;
     @apply .pt-6;
     @apply .px-2;
@@ -12,6 +12,6 @@
     @apply .no-underline;
     @apply .mb-4;
     @apply .mt-0;
-    @apply .text-gray-800;
+    @apply .text-white;
     @apply .text-sm;
 }

--- a/source/_components/newsletter-signup.blade.php
+++ b/source/_components/newsletter-signup.blade.php
@@ -1,4 +1,4 @@
-<div class="flex justify-center lg:-mx-12 my-12 p-6 md:px-12 bg-gray-200 border border-gray-400 text-sm md:rounded shadow">
+<div class="flex justify-center lg:-mx-12 my-12 p-6 md:px-12 bg-gray-700 border border-gray-700 text-sm md:rounded shadow">
     <!-- Begin Mailchimp Signup Form -->
     <div id="mc_embed_signup">
         <form action="https://your-mail-chimp-list-manage-url" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>

--- a/source/_components/post-preview-inline.blade.php
+++ b/source/_components/post-preview-inline.blade.php
@@ -1,5 +1,5 @@
 <div class="flex flex-col mb-4">
-    <p class="text-gray-700 font-medium my-2">
+    <p class="text-gray-300 font-medium my-2">
         {{ $post->getDate()->format('F j, Y') }}
     </p>
 
@@ -7,7 +7,7 @@
         <a
             href="{{ $post->getUrl() }}"
             title="Read more - {{ $post->title }}"
-            class="text-gray-900 font-extrabold"
+            class="text-gray-300 font-extrabold"
         >{{ $post->title }}</a>
     </h2>
 

--- a/source/_layouts/master.blade.php
+++ b/source/_layouts/master.blade.php
@@ -27,14 +27,14 @@
         <link rel="stylesheet" href="{{ mix('css/main.css', 'assets/build') }}">
     </head>
 
-    <body class="flex flex-col justify-between min-h-screen bg-gray-100 text-gray-800 leading-normal font-sans">
-        <header class="flex items-center shadow bg-white border-b h-24 py-4" role="banner">
+    <body class="flex flex-col justify-between min-h-screen bg-gray-800 text-white leading-normal font-sans">
+        <header class="flex items-center shadow bg-gray-900 h-24 py-4" role="banner">
             <div class="container flex items-center max-w-8xl mx-auto px-4 lg:px-8">
                 <div class="flex items-center">
                     <a href="/" title="{{ $page->siteName }} home" class="inline-flex items-center">
                         <img class="h-8 md:h-10 mr-3" src="/assets/img/logo.svg" alt="{{ $page->siteName }} logo" />
 
-                        <h1 class="text-lg md:text-2xl text-blue-800 font-semibold hover:text-blue-600 my-0">{{ $page->siteName }}</h1>
+                        <h1 class="text-lg md:text-2xl text-white font-semibold hover:text-gray-300 my-0">{{ $page->siteName }}</h1>
                     </a>
                 </div>
 
@@ -54,7 +54,7 @@
             @yield('body')
         </main>
 
-        <footer class="bg-white text-center text-sm mt-12 py-4" role="contentinfo">
+        <footer class="bg-gray-900 text-center text-sm mt-12 py-4" role="contentinfo">
             <ul class="flex flex-col md:flex-row justify-center list-none">
                 <li class="md:mr-2">
                     &copy; <a href="https://tighten.co" title="Tighten website">Tighten</a> {{ date('Y') }}.

--- a/source/_layouts/post.blade.php
+++ b/source/_layouts/post.blade.php
@@ -14,7 +14,7 @@
 
     <h1 class="leading-none mb-2">{{ $page->title }}</h1>
 
-    <p class="text-gray-700 text-xl md:mt-0">{{ $page->author }}  •  {{ date('F j, Y', $page->date) }}</p>
+    <p class="text-gray-300 text-xl md:mt-0">{{ $page->author }}  •  {{ date('F j, Y', $page->date) }}</p>
 
     @if ($page->categories)
         @foreach ($page->categories as $i => $category)

--- a/source/_nav/menu.blade.php
+++ b/source/_nav/menu.blade.php
@@ -1,16 +1,16 @@
 <nav class="hidden lg:flex items-center justify-end text-lg">
     <a title="{{ $page->siteName }} Blog" href="/blog"
-        class="ml-6 text-gray-700 hover:text-blue-600 {{ $page->isActive('/blog') ? 'active text-blue-600' : '' }}">
+        class="ml-6 text-white hover:text-blue-600 {{ $page->isActive('/blog') ? 'active text-blue-600' : '' }}">
         Blog
     </a>
 
     <a title="{{ $page->siteName }} About" href="/about"
-        class="ml-6 text-gray-700 hover:text-blue-600 {{ $page->isActive('/about') ? 'active text-blue-600' : '' }}">
+        class="ml-6 text-white hover:text-blue-600 {{ $page->isActive('/about') ? 'active text-blue-600' : '' }}">
         About
     </a>
 
     <a title="{{ $page->siteName }} Contact" href="/contact"
-        class="ml-6 text-gray-700 hover:text-blue-600 {{ $page->isActive('/contact') ? 'active text-blue-600' : '' }}">
+        class="ml-6 text-white hover:text-blue-600 {{ $page->isActive('/contact') ? 'active text-blue-600' : '' }}">
         Contact
     </a>
 </nav>

--- a/source/blog.blade.php
+++ b/source/blog.blade.php
@@ -31,7 +31,7 @@ pagination:
                 <a
                     href="{{ $previous }}"
                     title="Previous Page"
-                    class="bg-gray-200 hover:bg-gray-400 rounded mr-3 px-5 py-3"
+                    class="bg-gray-900 hover:bg-gray-400 rounded mr-3 px-5 py-3"
                 >&LeftArrow;</a>
             @endif
 
@@ -39,7 +39,7 @@ pagination:
                 <a
                     href="{{ $path }}"
                     title="Go to Page {{ $pageNumber }}"
-                    class="bg-gray-200 hover:bg-gray-400 text-blue-700 rounded mr-3 px-5 py-3 {{ $pagination->currentPage == $pageNumber ? 'text-blue-600' : '' }}"
+                    class="bg-gray-900 hover:bg-gray-400 text-blue-700 rounded mr-3 px-5 py-3 {{ $pagination->currentPage == $pageNumber ? 'text-blue-600' : '' }}"
                 >{{ $pageNumber }}</a>
             @endforeach
 
@@ -47,7 +47,7 @@ pagination:
                 <a
                     href="{{ $next }}"
                     title="Next Page"
-                    class="bg-gray-200 hover:bg-gray-400 rounded mr-3 px-5 py-3"
+                    class="bg-gray-900 hover:bg-gray-400 rounded mr-3 px-5 py-3"
                 >&RightArrow;</a>
             @endif
         </nav>

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -7,12 +7,12 @@
                 <img src="{{ $featuredPost->cover_image }}" alt="{{ $featuredPost->title }} cover image" class="mb-6">
             @endif
 
-            <p class="text-gray-700 font-medium my-2">
+            <p class="text-gray-300 font-medium my-2">
                 {{ $featuredPost->getDate()->format('F j, Y') }}
             </p>
 
             <h2 class="text-3xl mt-0">
-                <a href="{{ $featuredPost->getUrl() }}" title="Read {{ $featuredPost->title }}" class="text-gray-900 font-extrabold">
+                <a href="{{ $featuredPost->getUrl() }}" title="Read {{ $featuredPost->title }}" class="text-gray-300 font-extrabold">
                     {{ $featuredPost->title }}
                 </a>
             </h2>


### PR DESCRIPTION
Hey!

I have created here a dark theme implementation for the blog template. 

As for how this would possibly be implemented, considered options I have thought of are as follows:

- add a switch on jigsaw init blog to include 'dark/light' and make files accordingly
- add as a new template option e.g. blog-dark and point to a new alternate template repo

If this was to go ahead would be happy to help with implementation, and creation of dark for docs, and black for both. I feel this would be a great alternative for the existing templates and save time for those who prefer a dark theme over light on new jigsaw sites.

Thanks.