### PR TITLE
Replace manual purgeCss with Tailwind's built-in version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
         "highlight.js": "^9.13.1",
         "laravel-mix": "^4.0.0||^5.0.0",
         "laravel-mix-jigsaw": "^1.0.0",
-        "laravel-mix-purgecss": "^4.0.0||^5.0.0",
         "sass": "^1.15.2",
         "sass-loader": "^7.1.0",
         "tailwindcss": "^1.0.4",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,20 @@
 module.exports = {
+  purge: {
+    content: [
+      'source/**/*.html',
+      'source/**/*.md',
+      'source/**/*.js',
+      'source/**/*.php',
+      'source/**/*.vue',
+    ],
+    options: {
+      whitelist: [
+        /language/,
+        /hljs/,
+        /mce/,
+      ],
+    },
+  },
   theme: {
     extend: {
       fontFamily: {

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,6 +1,5 @@
 const mix = require('laravel-mix');
 require('laravel-mix-jigsaw');
-require('laravel-mix-purgecss');
 
 mix.disableSuccessNotifications();
 mix.setPublicPath('source/assets/build');
@@ -15,10 +14,6 @@ mix.js('source/_assets/js/main.js', 'js')
         postCss: [
             require('tailwindcss'),
         ],
-    })
-    .purgeCss({
-        content: ['source/**/*.html', 'source/**/*.md', 'source/**/*.js', 'source/**/*.php', 'source/**/*.vue'],
-        whitelistPatterns: [/language/, /hljs/, /mce/],
     })
     .sourceMaps()
     .version();


### PR DESCRIPTION
This PR removes the manual configuration of purgeCss (along with the dependency), in favor of Tailwind's built-in implementation.